### PR TITLE
Add link to original source of schema.go

### DIFF
--- a/pkg/schemas/schema.go
+++ b/pkg/schemas/schema.go
@@ -14,6 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// This file is modified from https://github.com/kubernetes-sigs/controller-tools/blob/v0.7.0/pkg/crd/schema.go
+// Modifications are listed in // Note comments
+
 package schemas
 
 import (


### PR DESCRIPTION
`schema.go` was originally taken from https://github.com/kubernetes-sigs/controller-tools/blob/v0.7.0/pkg/crd/schema.go.
This PR adds a comment at the top of the file to link to this source.