### PR TITLE
fix: output multiple files

### DIFF
--- a/pkg/schemas/generator.go
+++ b/pkg/schemas/generator.go
@@ -137,7 +137,9 @@ func (g Generator) output(documents map[string]*apiext.JSONSchemaProps) error {
 			return err
 		}
 		_, err = f.Write(bytes)
-		return err
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
A previous commit resulted in early exit during write of output even when no error occurs  