### PR TITLE
Add explicit setup-go installation step prior to using golangci-lint-action

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -13,6 +13,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:


### PR DESCRIPTION
the changes are required by golangci-lint-action v3.0.0+
see golangci-lint-action

Signed-off-by: Alexey Roytman <roytman@il.ibm.com>