### PR TITLE
Gitlint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -98,7 +98,6 @@ linters:
     - unused
   #  - varcheck
     - whitespace
-  # temporary disable due to the bug to
     - revive
 
   # don't enable:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -98,6 +98,7 @@ linters:
     - unused
   #  - varcheck
     - whitespace
+  # temporary disable due to the bug to
     - revive
 
   # don't enable:

--- a/main.go
+++ b/main.go
@@ -64,6 +64,6 @@ func RootCmd() *cobra.Command {
 func main() {
 	if err := RootCmd().Execute(); err != nil {
 		fmt.Println(err)
-		os.Exit(1) //nolint:revive
+		os.Exit(1)
 	}
 }

--- a/pkg/schemas/generator.go
+++ b/pkg/schemas/generator.go
@@ -254,7 +254,7 @@ func indexOf(a string, list []string) int {
 			return i
 		}
 	}
-	return -1 //nolint:revive
+	return -1
 }
 
 // Remove fields that is not related to taxonomy
@@ -276,18 +276,18 @@ func (context *GeneratorContext) removeExtraProps(typeIdent crd.TypeIdent, v *ap
 			}
 			// If the field is not in the list of the needed fields then remove it from the schema
 			_, fieldKnownInfo := context.parser.Types[typeIdentField]
-			if indexOf(typeIdentField.Name, fieldTypes) == -1 || !fieldKnownInfo { //nolint:revive
+			if indexOf(typeIdentField.Name, fieldTypes) == -1 || !fieldKnownInfo {
 				jsonTag, hasTag := field.Tag.Lookup("json")
 				if !hasTag {
 					continue
 				}
 				jsonOpts := strings.Split(jsonTag, ",")
-				delete(v.Properties, jsonOpts[0])         //nolint:revive
-				index := indexOf(jsonOpts[0], v.Required) //nolint:revive
-				if index != -1 {                          //nolint:revive
+				delete(v.Properties, jsonOpts[0])
+				index := indexOf(jsonOpts[0], v.Required)
+				if index != -1 {
 					length := len(v.Required)
-					v.Required[index] = v.Required[length-1] //nolint:revive
-					v.Required = v.Required[:length-1]       //nolint:revive
+					v.Required[index] = v.Required[length-1]
+					v.Required = v.Required[:length-1]
 				}
 			}
 		}
@@ -350,7 +350,7 @@ func (context *GeneratorContext) definitionNameFor(documentName string, typeIden
 // escapes).
 func qualifiedName(pkgName, typeName string) string {
 	if pkgName != Empty {
-		return strings.Replace(pkgName, "/", "~1", -1) + "~0" + typeName //nolint:revive
+		return strings.Replace(pkgName, "/", "~1", -1) + "~0" + typeName
 	}
 	return typeName
 }
@@ -367,7 +367,7 @@ func (context *GeneratorContext) TypeRefLink(from *loader.Package, to crd.TypeId
 	// the `schema` marker or in a package with a type that has the `object` marker
 	// Otherwise, the suffix will be build using qualifiedName function
 	suffix := to.Name
-	if indexOf(to.Package.PkgPath, context.objectPkgs) == -1 { //nolint:revive
+	if indexOf(to.Package.PkgPath, context.objectPkgs) == -1 {
 		suffix = context.definitionNameFor(toDocument, to)
 	}
 	return prefix + suffix

--- a/pkg/schemas/schema.go
+++ b/pkg/schemas/schema.go
@@ -294,7 +294,7 @@ func mapToSchema(ctx *schemaContext, mapType *ast.MapType) *apiext.JSONSchemaPro
 	for keyInfo != nil {
 		switch typedKey := keyInfo.(type) {
 		case *types.Basic:
-			if typedKey.Info()&types.IsString == 0 { //nolint:revive
+			if typedKey.Info()&types.IsString == 0 {
 				ctx.pkg.AddError(loader.ErrFromNode(fmt.Errorf("map keys must be strings, not %s", keyInfo.String()), mapType.Key))
 				return &apiext.JSONSchemaProps{}
 			}
@@ -358,14 +358,14 @@ func structToSchema(ctx *schemaContext, structType *ast.StructType) *apiext.JSON
 			continue
 		}
 		jsonOpts := strings.Split(jsonTag, ",")
-		if len(jsonOpts) == 1 && jsonOpts[0] == "-" { //nolint:revive
+		if len(jsonOpts) == 1 && jsonOpts[0] == "-" {
 			// skipped fields have the tag "-" (note that "-," means the field is named "-")
 			continue
 		}
 
 		inline := false
 		omitEmpty := false
-		for _, opt := range jsonOpts[1:] { //nolint:revive
+		for _, opt := range jsonOpts[1:] {
 			switch opt {
 			case "inline":
 				inline = true
@@ -373,7 +373,7 @@ func structToSchema(ctx *schemaContext, structType *ast.StructType) *apiext.JSON
 				omitEmpty = true
 			}
 		}
-		fieldName := jsonOpts[0]              //nolint:revive
+		fieldName := jsonOpts[0]
 		inline = inline || fieldName == Empty // anonymous fields are inline fields in YAML/JSON
 
 		// if no default required mode is set, default to required
@@ -428,13 +428,13 @@ func builtinToType(basic *types.Basic, allowDangerousTypes bool) (typ, format st
 	// non-string types.
 	basicInfo := basic.Info()
 	switch {
-	case basicInfo&types.IsBoolean != 0: //nolint:revive
+	case basicInfo&types.IsBoolean != 0:
 		typ = "boolean"
-	case basicInfo&types.IsString != 0: //nolint:revive
+	case basicInfo&types.IsString != 0:
 		typ = "string"
-	case basicInfo&types.IsInteger != 0: //nolint:revive
+	case basicInfo&types.IsInteger != 0:
 		typ = "integer"
-	case basicInfo&types.IsFloat != 0: //nolint:revive
+	case basicInfo&types.IsFloat != 0:
 		if allowDangerousTypes {
 			typ = "number"
 		} else {


### PR DESCRIPTION
The v1.50.1 version of golangci-lint fixed the magic number bug of the `revive` linter, and the added as a temporal workaround `nolint:revive` directives started to be redundant and broke running the linter. 